### PR TITLE
Fix build of app bundle

### DIFF
--- a/tickle-repo-introspect-gui/.npmrc
+++ b/tickle-repo-introspect-gui/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/tickle-repo-introspect-gui/.npmrc
+++ b/tickle-repo-introspect-gui/.npmrc
@@ -1,1 +1,0 @@
-ignore-scripts=true

--- a/tickle-repo-introspect-gui/pom.xml
+++ b/tickle-repo-introspect-gui/pom.xml
@@ -41,17 +41,17 @@
                             <goal>npm</goal>
                         </goals>
                         <configuration>
-                            <arguments>install --ignore-scripts</arguments>
+                            <arguments>install</arguments>
                         </configuration>
                     </execution>
 
                     <execution>
-                        <id>npm run build</id>
+                        <id>webpack</id>
                         <goals>
-                            <goal>npm</goal>
+                            <goal>webpack</goal>
                         </goals>
                         <configuration>
-                            <arguments>run build</arguments>
+                            <arguments>-p</arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/tickle-repo-introspect-gui/pom.xml
+++ b/tickle-repo-introspect-gui/pom.xml
@@ -41,7 +41,7 @@
                             <goal>npm</goal>
                         </goals>
                         <configuration>
-                            <arguments>install</arguments>
+                            <arguments>install --ignore-scripts</arguments>
                         </configuration>
                     </execution>
 


### PR DESCRIPTION
The build did not include the js app bundle due to the ignore-script setting resulted in the npm run build silently not being executed, since the app is using an older npm version (5.*) where ignore-script is applied more broadly.